### PR TITLE
Restarts and Rollbacks return Result type

### DIFF
--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -21,8 +21,8 @@ import mesosphere.marathon.client.model.v2.Result;
 
 import feign.Headers;
 import feign.Param;
-import feign.RequestLine;
 import feign.QueryMap;
+import feign.RequestLine;
 
 public interface Marathon {
 	// Apps
@@ -32,7 +32,7 @@ public interface Marathon {
 
 	@RequestLine("GET /v2/apps")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-	GetAppsResponse getApps(@QueryMap Map<String,String> queryMap) throws MarathonException;
+	GetAppsResponse getApps(@QueryMap Map<String, String> queryMap) throws MarathonException;
 
 	@RequestLine("GET /v2/apps/{id}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
@@ -53,11 +53,11 @@ public interface Marathon {
 	@RequestLine("PUT /v2/apps/{app_id}?force={force}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	Result updateApp(@Param("app_id") String appId, App app,
-            @Param("force") boolean force) throws MarathonException;
+			@Param("force") boolean force) throws MarathonException;
 
 	@RequestLine("POST /v2/apps/{id}/restart?force={force}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-	void restartApp(@Param("id") String id,@Param("force") boolean force) throws MarathonException;
+	Result restartApp(@Param("id") String id, @Param("force") boolean force) throws MarathonException;
 
 	@RequestLine("DELETE /v2/apps/{id}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
@@ -77,11 +77,11 @@ public interface Marathon {
 	@RequestLine("POST /v2/groups")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	Result createGroup(Group group) throws MarathonException;
-	
+
 	@RequestLine("DELETE /v2/groups/{id}?force={force}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	Result deleteGroup(@Param("id") String id, @Param("force") boolean force) throws MarathonException;
-	
+
 	@RequestLine("GET /v2/groups/{id}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	Group getGroup(@Param("id") String id) throws MarathonException;
@@ -94,16 +94,16 @@ public interface Marathon {
 	@RequestLine("GET /v2/deployments")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	List<Deployment> getDeployments() throws MarathonException;
-	
+
 	@RequestLine("DELETE /v2/deployments/{deploymentId}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-	void cancelDeploymentAndRollback(@Param("deploymentId") String id) throws MarathonException;
-	
+	Result cancelDeploymentAndRollback(@Param("deploymentId") String id) throws MarathonException;
+
 	@RequestLine("DELETE /v2/deployments/{deploymentId}?force=true")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	void cancelDeployment(@Param("deploymentId") String id) throws MarathonException;
 
-    // Event Subscriptions
+	// Event Subscriptions
 	@RequestLine("POST /v2/eventSubscriptions?callbackUrl={url}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	public GetEventSubscriptionRegisterResponse register(@Param("url") String url) throws MarathonException;


### PR DESCRIPTION
Consulting the [REST API docs](https://mesosphere.github.io/marathon/docs/rest-api.html) explicitly mention that `DELETE /v2/deployments/{deploymentId}` and `POST /v2/apps/{appId}/restart` return a deployment response type.