### PR TITLE
Add Version Support to Marathon Client

### DIFF
--- a/src/main/java/mesosphere/dcos/client/DCOS.java
+++ b/src/main/java/mesosphere/dcos/client/DCOS.java
@@ -17,7 +17,7 @@ import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
 import mesosphere.marathon.client.model.v2.DeleteTaskCriteria;
 import mesosphere.marathon.client.model.v2.GetAbdicateLeaderResponse;
 import mesosphere.marathon.client.model.v2.GetAppNamespaceResponse;
-import mesosphere.marathon.client.model.v2.GetAppVersionResponse;
+import mesosphere.marathon.client.model.v2.GetAppVersionsResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionRegisterResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionsResponse;
 import mesosphere.marathon.client.model.v2.GetLeaderResponse;
@@ -98,16 +98,6 @@ public interface DCOS extends Marathon {
     DeleteAppTasksResponse deleteAppTasksAndWipeWithTaskId(@Param("appId") String appId,
                                                            @Param("taskId") String taskId,
                                                            @Param("force") boolean force)
-            throws DCOSException;
-
-    @RequestLine("GET /v2/apps/{appId}/versions")
-    @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-    GetAppVersionResponse getAppVersion(@Param("id") String appId) throws DCOSException;
-
-    @RequestLine("GET /v2/apps/{appId}/versions/{version}")
-    @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-    App getAppVersion(@Param("appId") String appId,
-                      @Param("version") String version)
             throws DCOSException;
 
     // Deployments

--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -10,6 +10,7 @@ import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
 import mesosphere.marathon.client.model.v2.Deployment;
 import mesosphere.marathon.client.model.v2.GetAppResponse;
 import mesosphere.marathon.client.model.v2.GetAppTasksResponse;
+import mesosphere.marathon.client.model.v2.GetAppVersionResponse;
 import mesosphere.marathon.client.model.v2.GetAppsResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionRegisterResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionsResponse;
@@ -42,6 +43,14 @@ public interface Marathon {
 	@RequestLine("GET /v2/apps/{id}/tasks")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
 	GetAppTasksResponse getAppTasks(@Param("id") String id) throws MarathonException;
+
+	@RequestLine("GET /v2/apps/{id}/versions")
+	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
+	GetAppVersionResponse getAppVersions(@Param("id") String id) throws MarathonException;
+
+	@RequestLine("GET /v2/apps/{id}/versions/{version}")
+	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
+	App getAppVersion(@Param("id") String id, @Param("version") String version) throws MarathonException;
 
 	@RequestLine("GET /v2/tasks")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)

--- a/src/main/java/mesosphere/marathon/client/Marathon.java
+++ b/src/main/java/mesosphere/marathon/client/Marathon.java
@@ -10,7 +10,7 @@ import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse;
 import mesosphere.marathon.client.model.v2.Deployment;
 import mesosphere.marathon.client.model.v2.GetAppResponse;
 import mesosphere.marathon.client.model.v2.GetAppTasksResponse;
-import mesosphere.marathon.client.model.v2.GetAppVersionResponse;
+import mesosphere.marathon.client.model.v2.GetAppVersionsResponse;
 import mesosphere.marathon.client.model.v2.GetAppsResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionRegisterResponse;
 import mesosphere.marathon.client.model.v2.GetEventSubscriptionsResponse;
@@ -46,7 +46,7 @@ public interface Marathon {
 
 	@RequestLine("GET /v2/apps/{id}/versions")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
-	GetAppVersionResponse getAppVersions(@Param("id") String id) throws MarathonException;
+	GetAppVersionsResponse getAppVersions(@Param("id") String id) throws MarathonException;
 
 	@RequestLine("GET /v2/apps/{id}/versions/{version}")
 	@Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)

--- a/src/main/java/mesosphere/marathon/client/model/v2/GetAppVersionsResponse.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/GetAppVersionsResponse.java
@@ -7,7 +7,7 @@ import mesosphere.client.common.ModelUtils;
 /**
  * Created by tt044106 on 10/28/16.
  */
-public class GetAppVersionResponse {
+public class GetAppVersionsResponse {
     private Collection<String> versions;
 
     public Collection<String> getVersions() {


### PR DESCRIPTION
* Moves `getAppVersion` and `getAppVersions` from `DCOS` to `Marathon`
* Corrects `GetAppVersionResponse` to be more correctly named `GetAppVersionsResponse`