### PR TITLE
Add Typing for env values

### DIFF
--- a/src/main/java/mesosphere/client/common/ModelUtils.java
+++ b/src/main/java/mesosphere/client/common/ModelUtils.java
@@ -1,16 +1,21 @@
 package mesosphere.client.common;
 
+import mesosphere.marathon.client.model.v2.EnvValue;
 import mesosphere.marathon.client.model.v2.Volume;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class ModelUtils {
-    public static final Gson GSON = new GsonBuilder().setPrettyPrinting()
-            .disableHtmlEscaping().registerTypeAdapter(Volume.class, new Volume.VolumeAdapter()).create();
+	public static final Gson GSON = new GsonBuilder()
+			.setPrettyPrinting()
+			.disableHtmlEscaping()
+			.registerTypeAdapter(Volume.class, new Volume.VolumeAdapter())
+			.registerTypeAdapter(EnvValue.class, new EnvValue.EnvValueAdapter())
+			.create();
 
-    public static String toString(Object o) {
-        return GSON.toJson(o);
-    }
+	public static String toString(Object o) {
+		return GSON.toJson(o);
+	}
 
 }

--- a/src/main/java/mesosphere/marathon/client/model/v2/App.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/App.java
@@ -1,6 +1,11 @@
 package mesosphere.marathon.client.model.v2;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import mesosphere.client.common.ModelUtils;
 
@@ -39,7 +44,7 @@ public class App {
 	private List<List<String>> constraints;
 	private Collection<String> acceptedResourceRoles;
 	private Container container;
-	private Map<String, Object> env;
+	private Map<String, EnvValue> env;
 	private Map<String, String> labels;
 	private IpAddress ipAddress;
 	private String version;
@@ -47,8 +52,8 @@ public class App {
 	private Integer taskKillGracePeriodSeconds;
 	private Map<String, SecretSource> secrets;
 	private String executor;
-    private List<Fetchable> fetch;
-    private List<String> storeUrls;
+	private List<Fetchable> fetch;
+	private List<String> storeUrls;
 	private List<Integer> ports;
 	private List<PortDefinition> portDefinitions;
 	private Boolean requirePorts;
@@ -57,7 +62,7 @@ public class App {
 	private Double backoffFactor;
 	private Integer maxLaunchDelaySeconds;
 	private Collection<Task> tasks;
-    private AppVersionInfo versionInfo;
+	private AppVersionInfo versionInfo;
 	private Integer tasksStaged;
 	private Integer tasksRunning;
 	private Integer tasksHealthy;
@@ -192,11 +197,11 @@ public class App {
 		this.container = container;
 	}
 
-	public Map<String, Object> getEnv() {
+	public Map<String, EnvValue> getEnv() {
 		return env;
 	}
 
-	public void setEnv(Map<String, Object> env) {
+	public void setEnv(Map<String, EnvValue> env) {
 		this.env = env;
 	}
 
@@ -265,13 +270,13 @@ public class App {
 		this.executor = executor;
 	}
 
-    public List<Fetchable> getFetch() {
-        return fetch;
-    }
+	public List<Fetchable> getFetch() {
+		return fetch;
+	}
 
-    public void setFetch(final List<Fetchable> fetch) {
-        this.fetch = fetch;
-    }
+	public void setFetch(final List<Fetchable> fetch) {
+		this.fetch = fetch;
+	}
 
 	public List<String> getStoreUrls() {
 		return storeUrls;
@@ -368,13 +373,13 @@ public class App {
 		this.tasks = tasks;
 	}
 
-    public AppVersionInfo getVersionInfo() {
-        return versionInfo;
-    }
+	public AppVersionInfo getVersionInfo() {
+		return versionInfo;
+	}
 
-    public void setVersionInfo(final AppVersionInfo versionInfo) {
-        this.versionInfo = versionInfo;
-    }
+	public void setVersionInfo(final AppVersionInfo versionInfo) {
+		this.versionInfo = versionInfo;
+	}
 
 	public Integer getTasksStaged() {
 		return tasksStaged;

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvSecret.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvSecret.java
@@ -1,0 +1,63 @@
+package mesosphere.marathon.client.model.v2;
+
+import mesosphere.client.common.ModelUtils;
+
+/**
+ * @author Lewis Headden <lewis_headden@condenast.com>
+ */
+public class EnvSecret extends EnvValue {
+	private String secret;
+
+	public EnvSecret(final String secret) {
+		this.secret = secret;
+
+	}
+
+	public String getSecret() {
+		return secret;
+	}
+
+	public void setSecret(final String secret) {
+		this.secret = secret;
+	}
+
+	@Override
+	public boolean isSecret() {
+		return true;
+	}
+
+	@Override
+	public EnvSecret getAsSecret() {
+		return this;
+	}
+
+	@Override
+	public boolean isString() {
+		return false;
+	}
+
+	@Override
+	public EnvString getAsString() {
+		throw new IllegalStateException(this.getClass().getSimpleName() + " is not a " + EnvString.class.getSimpleName());
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		final EnvSecret envSecret = (EnvSecret) o;
+
+		return secret != null ? secret.equals(envSecret.secret) : envSecret.secret == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return secret != null ? secret.hashCode() : 0;
+	}
+
+	@Override
+	public String toString() {
+		return ModelUtils.toString(this);
+	}
+}

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvSecret.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvSecret.java
@@ -27,7 +27,7 @@ public class EnvSecret extends EnvValue {
 	}
 
 	@Override
-	public EnvSecret getAsSecret() {
+	public EnvSecret asEnvSecret() {
 		return this;
 	}
 
@@ -37,7 +37,7 @@ public class EnvSecret extends EnvValue {
 	}
 
 	@Override
-	public EnvString getAsString() {
+	public EnvString asEnvString() {
 		throw new IllegalStateException(this.getClass().getSimpleName() + " is not a " + EnvString.class.getSimpleName());
 	}
 

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvString.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvString.java
@@ -1,0 +1,63 @@
+package mesosphere.marathon.client.model.v2;
+
+import mesosphere.client.common.ModelUtils;
+
+/**
+ * @author Lewis Headden <lewis_headden@condenast.com>
+ */
+public class EnvString extends EnvValue {
+	private String value;
+
+	public EnvString(final String value) {
+		this.value = value;
+	}
+
+	public void setValue(final String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean isSecret() {
+		return false;
+	}
+
+	@Override
+	public EnvSecret getAsSecret() {
+		throw new IllegalStateException(this.getClass().getSimpleName() + " is not a " + EnvSecret.class.getSimpleName());
+	}
+
+	@Override
+	public boolean isString() {
+		return true;
+	}
+
+	@Override
+	public EnvString getAsString() {
+		return this;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		final EnvString envString = (EnvString) o;
+
+		return value != null ? value.equals(envString.value) : envString.value == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return value != null ? value.hashCode() : 0;
+	}
+
+	@Override
+	public String toString() {
+		return ModelUtils.toString(this);
+	}
+
+}

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvString.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvString.java
@@ -26,7 +26,7 @@ public class EnvString extends EnvValue {
 	}
 
 	@Override
-	public EnvSecret getAsSecret() {
+	public EnvSecret asEnvSecret() {
 		throw new IllegalStateException(this.getClass().getSimpleName() + " is not a " + EnvSecret.class.getSimpleName());
 	}
 
@@ -36,7 +36,7 @@ public class EnvString extends EnvValue {
 	}
 
 	@Override
-	public EnvString getAsString() {
+	public EnvString asEnvString() {
 		return this;
 	}
 

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
@@ -29,7 +29,11 @@ public abstract class EnvValue {
 		public EnvValue deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
 			if (jsonElement.isJsonObject() && jsonElement.getAsJsonObject().has("secret"))
 				return jsonDeserializationContext.deserialize(jsonElement, EnvSecret.class);
-			else return new EnvString(jsonElement.getAsString());
+			else if (jsonElement.isJsonPrimitive()) {
+				return new EnvString(jsonElement.getAsString());
+			} else {
+				throw new IllegalStateException("Cannot deserialize " + jsonElement.toString() + " as EnvValue");
+			}
 		}
 
 		@Override

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
@@ -17,11 +17,11 @@ public abstract class EnvValue {
 
 	public abstract boolean isSecret();
 
-	public abstract EnvSecret getAsSecret();
+	public abstract EnvSecret asEnvSecret();
 
 	public abstract boolean isString();
 
-	public abstract EnvString getAsString();
+	public abstract EnvString asEnvString();
 
 	public static class EnvValueAdapter implements JsonDeserializer<EnvValue>, JsonSerializer<EnvValue> {
 

--- a/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/EnvValue.java
@@ -1,0 +1,47 @@
+package mesosphere.marathon.client.model.v2;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * @author Lewis Headden <lewis_headden@condenast.com>
+ */
+public abstract class EnvValue {
+
+	public abstract boolean isSecret();
+
+	public abstract EnvSecret getAsSecret();
+
+	public abstract boolean isString();
+
+	public abstract EnvString getAsString();
+
+	public static class EnvValueAdapter implements JsonDeserializer<EnvValue>, JsonSerializer<EnvValue> {
+
+		@Override
+		public EnvValue deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+			if (jsonElement.isJsonObject() && jsonElement.getAsJsonObject().has("secret"))
+				return jsonDeserializationContext.deserialize(jsonElement, EnvSecret.class);
+			else return new EnvString(jsonElement.getAsString());
+		}
+
+		@Override
+		public JsonElement serialize(EnvValue envValue, Type type, JsonSerializationContext jsonSerializationContext) {
+			if (envValue instanceof EnvString) {
+				return new JsonPrimitive(((EnvString) envValue).getValue());
+			} else if (envValue instanceof EnvSecret) {
+				return jsonSerializationContext.serialize(envValue);
+			} else {
+				throw new IllegalStateException("Cannot serialize " + envValue.getClass());
+			}
+		}
+	}
+
+}

--- a/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
+++ b/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
@@ -103,7 +103,8 @@ class AppSpec extends Specification {
 
     expect:
     // env
-    app.getEnv().get("PASSWORD") == ["secret": "/db/password"]
+    app.getEnv().get("XPS1") == new EnvString("Test")
+    app.getEnv().get("PASSWORD") == new EnvSecret("/db/password")
 
     // port definitions
     portDefs.size() == 2

--- a/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
+++ b/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
@@ -141,7 +141,21 @@ class AppSpec extends Specification {
 
   }
 
-  def exampleJSON() {
+  def "example JSON is same when deserialized and re-serialized"() {
+    given:
+    def json = exampleJSON()
+
+    def app = ModelUtils.GSON.fromJson(json, App.class)
+    def reserializedApp = ModelUtils.GSON.toJson(app);
+    def deserializedApp = ModelUtils.GSON.fromJson(reserializedApp, App.class);
+    def reserializedAppAgain = ModelUtils.GSON.toJson(deserializedApp);
+
+    expect:
+    reserializedApp == reserializedAppAgain
+  }
+
+
+    def exampleJSON() {
     return """
 {
   "id": "/foo",


### PR DESCRIPTION
* Add news `EnvValue` types and subtypes `EnvString` and `EnvSecret`
* Changes signature of `env` from `Map<String, Object>` to `Map<String, EnvValue>`
* Adds test which covers deserializing and re-serializing `App` to ensure appropriate `TypeAdapters` are registered for `gson`