### PR TITLE
Support both Marathon `1.4` and `1.5` API schemas

### DIFF
--- a/src/main/java/mesosphere/marathon/client/model/v2/App.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/App.java
@@ -46,8 +46,8 @@ public class App {
 	private Integer taskKillGracePeriodSeconds;
 	private Map<String, SecretSource> secrets;
 	private String executor;
-    private List<Fetchable> fetch;
-    private List<String> storeUrls;
+	private List<Fetchable> fetch;
+	private List<String> storeUrls;
 	private List<Integer> ports;
 	private List<PortDefinition> portDefinitions;
 	private Boolean requirePorts;
@@ -56,7 +56,7 @@ public class App {
 	private Double backoffFactor;
 	private Integer maxLaunchDelaySeconds;
 	private Collection<Task> tasks;
-    private AppVersionInfo versionInfo;
+	private AppVersionInfo versionInfo;
 	private Integer tasksStaged;
 	private Integer tasksRunning;
 	private Integer tasksHealthy;
@@ -64,6 +64,7 @@ public class App {
 	private List<HealthCheck> healthChecks;
 	private List<ReadinessCheck> readinessChecks;
 	private UpgradeStrategy upgradeStrategy;
+	private List<Network> networks;
 
 	private List<Deployment> deployments;
 	private TaskFailure lastTaskFailure;
@@ -256,13 +257,13 @@ public class App {
 		this.executor = executor;
 	}
 
-    public List<Fetchable> getFetch() {
-        return fetch;
-    }
+	public List<Fetchable> getFetch() {
+		return fetch;
+	}
 
-    public void setFetch(final List<Fetchable> fetch) {
-        this.fetch = fetch;
-    }
+	public void setFetch(final List<Fetchable> fetch) {
+		this.fetch = fetch;
+	}
 
 	public List<String> getStoreUrls() {
 		return storeUrls;
@@ -359,13 +360,13 @@ public class App {
 		this.tasks = tasks;
 	}
 
-    public AppVersionInfo getVersionInfo() {
-        return versionInfo;
-    }
+	public AppVersionInfo getVersionInfo() {
+		return versionInfo;
+	}
 
-    public void setVersionInfo(final AppVersionInfo versionInfo) {
-        this.versionInfo = versionInfo;
-    }
+	public void setVersionInfo(final AppVersionInfo versionInfo) {
+		this.versionInfo = versionInfo;
+	}
 
 	public Integer getTasksStaged() {
 		return tasksStaged;
@@ -417,6 +418,14 @@ public class App {
 
 	public UpgradeStrategy getUpgradeStrategy() {
 		return upgradeStrategy;
+	}
+
+	public List<Network> getNetworks() {
+		return networks;
+	}
+
+	public void setNetworks(List<Network> networks) {
+		this.networks = networks;
 	}
 
 	public List<Deployment> getDeployments() {

--- a/src/main/java/mesosphere/marathon/client/model/v2/Container.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/Container.java
@@ -8,6 +8,7 @@ public class Container {
 	private String type;
 	private Docker docker;
 	private Collection<Volume> volumes;
+	private Collection<Port> portMappings;
 
 	public String getType() {
 		return type;
@@ -31,6 +32,14 @@ public class Container {
 
 	public void setVolumes(Collection<Volume> volumes) {
 		this.volumes = volumes;
+	}
+
+	public Collection<Port> getPortMappings() {
+		return portMappings;
+	}
+
+	public void setPortMappings(Collection<Port> portMappings) {
+		this.portMappings = portMappings;
 	}
 
 	@Override

--- a/src/main/java/mesosphere/marathon/client/model/v2/Network.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/Network.java
@@ -1,0 +1,41 @@
+package mesosphere.marathon.client.model.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import mesosphere.client.common.ModelUtils;
+
+public class Network {
+	public String name;
+	public String mode;
+	private Map<String, String> labels = new HashMap<>();
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getMode() {
+		return mode;
+	}
+
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+
+	public Map<String, String> getLabels() {
+		return labels;
+	}
+
+	public void setLabels(Map<String, String> labels) {
+		this.labels = labels;
+	}
+
+	@Override
+	public String toString() {
+		return ModelUtils.toString(this);
+	}
+}

--- a/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
+++ b/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
@@ -8,140 +8,169 @@ class AppSpec extends Specification {
   def app = new App()
 
   def "allows multiple roles"() {
-    def firstRole = "arole"
-    def secondRole = "another"
+	def firstRole = "arole"
+	def secondRole = "another"
 
-    when:
-    app.addAcceptedResourceRole(firstRole)
+	when:
+	app.addAcceptedResourceRole(firstRole)
 
-    then:
-    app.acceptedResourceRoles.contains(firstRole)
+	then:
+	app.acceptedResourceRoles.contains(firstRole)
 
-    when:
-    app.addAcceptedResourceRole(secondRole)
+	when:
+	app.addAcceptedResourceRole(secondRole)
 
-    then:
-    app.acceptedResourceRoles.contains(firstRole)
-    app.acceptedResourceRoles.contains(secondRole)
+	then:
+	app.acceptedResourceRoles.contains(firstRole)
+	app.acceptedResourceRoles.contains(secondRole)
 
-    when:
-    app.addAcceptedResourceRole(firstRole)
+	when:
+	app.addAcceptedResourceRole(firstRole)
 
-    then:
-    app.acceptedResourceRoles.contains(firstRole)
+	then:
+	app.acceptedResourceRoles.contains(firstRole)
   }
 
 
   def "test add dependency"() {
-    def firstDep = "adep"
-    def secondDep = "another"
+	def firstDep = "adep"
+	def secondDep = "another"
 
-    when:
-    app.addDependency(firstDep)
+	when:
+	app.addDependency(firstDep)
 
-    then:
-    app.getDependencies().contains(firstDep)
+	then:
+	app.getDependencies().contains(firstDep)
 
-    when:
-    app.addDependency(secondDep)
+	when:
+	app.addDependency(secondDep)
 
-    then:
-    app.getDependencies().contains(firstDep)
-    app.getDependencies().contains(secondDep)
+	then:
+	app.getDependencies().contains(firstDep)
+	app.getDependencies().contains(secondDep)
 
-    when:
-    app.addDependency(firstDep)
+	when:
+	app.addDependency(firstDep)
 
-    then:
-    app.getDependencies().contains(firstDep)
+	then:
+	app.getDependencies().contains(firstDep)
 
   }
 
   def "backoff factor checks"() {
-    app.backoffFactor = 0.1
+	app.backoffFactor = 0.1
 
-    expect:
-    app.backoffFactor == 0.1
+	expect:
+	app.backoffFactor == 0.1
 
-    when:
-    app.backoffFactor = 1d
+	when:
+	app.backoffFactor = 1d
 
-    then:
-    app.backoffFactor == 1.0
+	then:
+	app.backoffFactor == 1.0
   }
 
   def "residency tests"() {
-    def residency = new Residency()
-    residency.relaunchEscalationTimeoutSeconds = 60
-    residency.taskLostBehavior = "WAIT_FOREVER"
+	def residency = new Residency()
+	residency.relaunchEscalationTimeoutSeconds = 60
+	residency.taskLostBehavior = "WAIT_FOREVER"
 
-    expect:
-    !app.residency
+	expect:
+	!app.residency
 
-    when:
-    app.residency = residency
+	when:
+	app.residency = residency
 
-    then:
-    app.residency.relaunchEscalationTimeoutSeconds == 60
-    app.residency.taskLostBehavior == "WAIT_FOREVER"
+	then:
+	app.residency.relaunchEscalationTimeoutSeconds == 60
+	app.residency.taskLostBehavior == "WAIT_FOREVER"
 
-    when:
-    app.residency.taskLostBehavior = "INVALID_BEHAVIOR"
+	when:
+	app.residency.taskLostBehavior = "INVALID_BEHAVIOR"
 
-    then:
-    app.residency.taskLostBehavior == "INVALID_BEHAVIOR"
+	then:
+	app.residency.taskLostBehavior == "INVALID_BEHAVIOR"
   }
 
   def "test example JSON"() {
-    given:
-    def json = exampleJSON()
+	given:
+	def json = exampleJSON()
 
-    def app = ModelUtils.GSON.fromJson(json, App.class)
-    def portDefs = app.getPortDefinitions()
-    def fetch2 = app.fetch[1]
-    def discovery = app.ipAddress.discovery
+	def app = ModelUtils.GSON.fromJson(json, App.class)
+	def portDefs = app.getPortDefinitions()
+	def fetch2 = app.fetch[1]
+	def discovery = app.ipAddress.discovery
 
-    expect:
-    // env
-    app.getEnv().get("PASSWORD") == ["secret": "/db/password"]
+	expect:
+	// env
+	app.getEnv().get("PASSWORD") == ["secret": "/db/password"]
 
-    // port definitions
-    portDefs.size() == 2
-    portDefs[0].port == 0
-    portDefs[0].protocol == "tcp"
-    portDefs[0].name == "http"
-    portDefs[0].labels == ["vip": "192.168.0.1:80"]
-    portDefs[1].port == 31009
-    portDefs[1].protocol == "tcp"
-    portDefs[1].labels == ["VIP_0": "3.3.3.3"]
+	// port definitions
+	portDefs.size() == 2
+	portDefs[0].port == 0
+	portDefs[0].protocol == "tcp"
+	portDefs[0].name == "http"
+	portDefs[0].labels == ["vip": "192.168.0.1:80"]
+	portDefs[1].port == 31009
+	portDefs[1].protocol == "tcp"
+	portDefs[1].labels == ["VIP_0": "3.3.3.3"]
 
-    // fetch
-    app.fetch.size() == 2
-    fetch2.uri == "https://foo.com/archive.zip"
-    !fetch2.executable
-    fetch2.extract
-    fetch2.cache
-    fetch2.outputFile == "newname.zip"
+	// fetch
+	app.fetch.size() == 2
+	fetch2.uri == "https://foo.com/archive.zip"
+	!fetch2.executable
+	fetch2.extract
+	fetch2.cache
+	fetch2.outputFile == "newname.zip"
 
-    //secrets
-    app.secrets.size() == 2
-    app.secrets.secret3.source == "/foo2"
+	//secrets
+	app.secrets.size() == 2
+	app.secrets.secret3.source == "/foo2"
 
-    // ipaddress
-    discovery.ports.size() == 1
-    discovery.ports[0].number == 8080
-    discovery.ports[0].name == "rest-endpoint"
-    app.ipAddress.labels["environment"] == "dev"
-    app.ipAddress.groups[0] == "dev"
+	// ipaddress
+	discovery.ports.size() == 1
+	discovery.ports[0].number == 8080
+	discovery.ports[0].name == "rest-endpoint"
+	app.ipAddress.labels["environment"] == "dev"
+	app.ipAddress.groups[0] == "dev"
 
-    // residency
-    app.residency.relaunchEscalationTimeoutSeconds == 60
-    app.residency.taskLostBehavior == "WAIT_FOREVER"
+	// residency
+	app.residency.relaunchEscalationTimeoutSeconds == 60
+	app.residency.taskLostBehavior == "WAIT_FOREVER"
+
+	// container.docker.portMappings
+	app.container.docker.portMappings[0].name == "http"
+	app.container.docker.portMappings[0].protocol == "tcp"
+	app.container.docker.portMappings[0].containerPort == 80
+	app.container.docker.portMappings[0].servicePort == 10019
+
+	// container.docker.network
+	app.container.docker.network == "BRIDGE"
 
   }
 
+  def "test example JSON 1.5"() {
+	given:
+	def json = exampleJSON_15()
+
+	def app = ModelUtils.GSON.fromJson(json, App.class)
+
+	expect:
+	// container.portMappings
+	app.container.portMappings[0].name == "http"
+	app.container.portMappings[0].protocol == "tcp"
+	app.container.portMappings[0].containerPort == 80
+	app.container.portMappings[0].servicePort == 10019
+
+	// networks
+	app.networks[0].name == "default"
+	app.networks[0].mode == "container/bridge"
+
+  }
+
+
   def exampleJSON() {
-    return """
+	return """
 {
   "id": "/foo",
   "instances": 2,
@@ -150,162 +179,215 @@ class AppSpec extends Specification {
   "disk": 0,
   "mem": 16,
   "acceptedResourceRoles": [
-    "mesos_role"
+	"mesos_role"
   ],
   "args": [
-    "sleep",
-    "100"
+	"sleep",
+	"100"
   ],
   "backoffFactor": 1.15,
   "backoffSeconds": 1,
   "constraints": [
-    [
-      "hostname",
-      "LIKE",
-      "srv2.*"
-    ]
+	[
+	  "hostname",
+	  "LIKE",
+	  "srv2.*"
+	]
   ],
   "container": {
-    "docker": {
-      "forcePullImage": false,
-      "image": "mesosphere:marathon/latest",
-      "network": "BRIDGE",
-      "parameters": [
-        {
-          "key": "name",
-          "value": "kdc"
-        }
-      ],
-      "portMappings": [
-        {
-          "containerPort": 80,
-          "hostPort": 0,
-          "protocol": "tcp",
-          "servicePort": 10019,
-          "name": "http",
-          "labels": {
-            "vip": "192.168.0.1:80"
-          }
-        }
-      ],
-      "privileged": false
-    },
-    "type": "DOCKER",
-    "volumes": [
-      {
-        "containerPath": "/docker_storage",
-        "hostPath": "/hdd/tools/docker/registry",
-        "mode": "RW"
-      }
-    ]
+	"docker": {
+	  "forcePullImage": false,
+	  "image": "mesosphere:marathon/latest",
+	  "network": "BRIDGE",
+	  "parameters": [
+		{
+		  "key": "name",
+		  "value": "kdc"
+		}
+	  ],
+	  "portMappings": [
+		{
+		  "containerPort": 80,
+		  "hostPort": 0,
+		  "protocol": "tcp",
+		  "servicePort": 10019,
+		  "name": "http",
+		  "labels": {
+			"vip": "192.168.0.1:80"
+		  }
+		}
+	  ],
+	  "privileged": false
+	},
+	"type": "DOCKER",
+	"volumes": [
+	  {
+		"containerPath": "/docker_storage",
+		"hostPath": "/hdd/tools/docker/registry",
+		"mode": "RW"
+	  }
+	]
   },
   "dependencies": [
-    "/prod/group"
+	"/prod/group"
   ],
   "env": {
-    "XPS1": "Test",
-    "XPS2": "Rest",
-    "PASSWORD": {
-      "secret": "/db/password"
-    }
+	"XPS1": "Test",
+	"XPS2": "Rest",
+	"PASSWORD": {
+	  "secret": "/db/password"
+	}
   },
   "executor": "",
   "healthChecks": [
-    {
-      "gracePeriodSeconds": 300,
-      "ignoreHttp1xx": false,
-      "intervalSeconds": 20,
-      "maxConsecutiveFailures": 3,
-      "path": "/",
-      "portIndex": 0,
-      "protocol": "HTTP",
-      "timeoutSeconds": 20
-    }
+	{
+	  "gracePeriodSeconds": 300,
+	  "ignoreHttp1xx": false,
+	  "intervalSeconds": 20,
+	  "maxConsecutiveFailures": 3,
+	  "path": "/",
+	  "portIndex": 0,
+	  "protocol": "HTTP",
+	  "timeoutSeconds": 20
+	}
   ],
   "readinessChecks": [
-    {
-      "name": "myReadyCheck",
-      "protocol": "HTTP",
-      "path": "/v1/plan",
-      "portName": "http",
-      "intervalSeconds": 10,
-      "timeoutSeconds": 3,
-      "httpStatusCodesForReady": [
-        200
-      ],
-      "preserveLastResponse": true
-    }
+	{
+	  "name": "myReadyCheck",
+	  "protocol": "HTTP",
+	  "path": "/v1/plan",
+	  "portName": "http",
+	  "intervalSeconds": 10,
+	  "timeoutSeconds": 3,
+	  "httpStatusCodesForReady": [
+		200
+	  ],
+	  "preserveLastResponse": true
+	}
   ],
   "labels": {
-    "owner": "zeus",
-    "note": "Away from olympus"
+	"owner": "zeus",
+	"note": "Away from olympus"
   },
   "maxLaunchDelaySeconds": 3600,
   "ipAddress": {
-    "discovery": {
-      "ports": [
-        {
-          "number": 8080,
-          "name": "rest-endpoint",
-          "protocol": "tcp"
-        }
-      ]
-    },
-    "groups": [
-      "dev"
-    ],
-    "labels": {
-      "environment": "dev"
-    }
+	"discovery": {
+	  "ports": [
+		{
+		  "number": 8080,
+		  "name": "rest-endpoint",
+		  "protocol": "tcp"
+		}
+	  ]
+	},
+	"groups": [
+	  "dev"
+	],
+	"labels": {
+	  "environment": "dev"
+	}
   },
   "portDefinitions": [
-    {
-      "port": 0,
-      "protocol": "tcp",
-      "name": "http",
-      "labels": {
-        "vip": "192.168.0.1:80"
-      }
-    },
-    {
-      "port": 31009,
-      "protocol": "tcp",
-      "labels": {
-        "VIP_0": "3.3.3.3"
-      }
-    }
+	{
+	  "port": 0,
+	  "protocol": "tcp",
+	  "name": "http",
+	  "labels": {
+		"vip": "192.168.0.1:80"
+	  }
+	},
+	{
+	  "port": 31009,
+	  "protocol": "tcp",
+	  "labels": {
+		"VIP_0": "3.3.3.3"
+	  }
+	}
   ],
   "requirePorts": false,
   "upgradeStrategy": {
-    "maximumOverCapacity": 1,
-    "minimumHealthCapacity": 1
+	"maximumOverCapacity": 1,
+	"minimumHealthCapacity": 1
   },
   "fetch": [
-    {
-      "uri": "https://foo.com/setup.py"
-    },
-    {
-      "uri": "https://foo.com/archive.zip",
-      "executable": false,
-      "extract": true,
-      "cache": true,
-      "outputFile": "newname.zip"
-    }
+	{
+	  "uri": "https://foo.com/setup.py"
+	},
+	{
+	  "uri": "https://foo.com/archive.zip",
+	  "executable": false,
+	  "extract": true,
+	  "cache": true,
+	  "outputFile": "newname.zip"
+	}
   ],
   "user": "root",
   "secrets": {
-    "secret1": {
-      "source": "/db/password"
-    },
-    "secret3": {
-      "source": "/foo2"
-    }
+	"secret1": {
+	  "source": "/db/password"
+	},
+	"secret3": {
+	  "source": "/foo2"
+	}
   },
   "taskKillGracePeriodSeconds": 30,
   "residency": {
-    "relaunchEscalationTimeoutSeconds": 60,
-    "taskLostBehavior": "WAIT_FOREVER"
+	"relaunchEscalationTimeoutSeconds": 60,
+	"taskLostBehavior": "WAIT_FOREVER"
   }
+}
+"""
+  }
+
+  def exampleJSON_15() {
+	return """
+{
+  "id": "/foo",
+  "instances": 2,
+  "cmd": "sleep 1000",
+  "cpus": 0.1,
+  "disk": 0,
+  "mem": 16,
+  "container": {
+	"docker": {
+	  "forcePullImage": false,
+	  "image": "mesosphere:marathon/latest",
+	  "parameters": [
+		{
+		  "key": "name",
+		  "value": "kdc"
+		}
+	  ],
+	  "privileged": false
+	},
+	"type": "DOCKER",
+	"volumes": [
+	  {
+		"containerPath": "/docker_storage",
+		"hostPath": "/hdd/tools/docker/registry",
+		"mode": "RW"
+	  }
+	],
+	"portMappings": [
+	  {
+		"containerPort": 80,
+		"hostPort": 0,
+		"protocol": "tcp",
+		"servicePort": 10019,
+		"name": "http",
+		"labels": {
+		  "vip": "192.168.0.1:80"
+		}
+	  }
+	]
+  },
+  "networks": [
+	{
+	  "name": "default",
+	  "mode": "container/bridge",
+	  "labels": {}
+	}
+  ]
 }
 """
   }


### PR DESCRIPTION
- `portMappings` under both `container.docker` and `container`
- new `networks` app-level array